### PR TITLE
OMS-137-make-external_id-optional-in-PO items

### DIFF
--- a/src/purchase-order/item.ts
+++ b/src/purchase-order/item.ts
@@ -3,7 +3,7 @@ export interface PurchaseOrderItem {
   description: string;
   discount?: number;
   discountAmount?: number;
-  externalId: string;
+  externalId?: string;
   id: string;
   lineItemId: string;
   name: string;


### PR DESCRIPTION
## :memo: Description

Make external_id optional in PO items

### :gem: Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
